### PR TITLE
Added settings.py to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 
 # Created by https://www.gitignore.io/api/python
+### discord-bot-template ###
+settings.py
 
 ### Python ###
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
Adding settings.py to .gitignore will help prevent users from accidentally uploading their bot's API token to Github or other code sharing sites.